### PR TITLE
add support for station metadata from OSCAR/Surface API

### DIFF
--- a/csv2bufr/cli.py
+++ b/csv2bufr/cli.py
@@ -111,10 +111,10 @@ def transform(ctx, csv_file, mapping, output_dir, station_metadata, verbosity):
             raise click.ClickException(err)
 
     click.echo("Writing data to file")
-    for item in result:
-        filename = f"{output_dir}{os.sep}{item}.bufr4"
+    for key, value in result.items():
+        filename = f"{output_dir}{os.sep}{key}.bufr4"
         with open(filename, "wb") as fh:
-            fh.write(result[item].read())
+            fh.write(value.read())
 
     click.echo("Done")
     return 0


### PR DESCRIPTION
Extends `station_metadata` concept to support OSCAR/Surface API output (converts to internal csv2bufr station metadata format to align to mapping validation).

Ideally the mapping validation could can directly work with the OSCAR/Surface API output, and negate the need for internal conversion (in which case, happy to close this PR instead).