### PR TITLE
move md5 to _meta

### DIFF
--- a/csv2bufr/__init__.py
+++ b/csv2bufr/__init__.py
@@ -640,7 +640,6 @@ def transform(data: str, metadata: dict, mappings: dict,
 
         # now md5 as the key for this obs.
         rmk = message.md5()
-        result["md5"] = rmk
 
         # now create GeoJSON if specified
         if template:
@@ -651,6 +650,7 @@ def transform(data: str, metadata: dict, mappings: dict,
         LOGGER.debug("Adding metadata elements")
         result["_meta"] = {
             "identifier": rmk,
+            "md5": rmk,
             "data_date": message.get_datetime(),
             "originating_centre": message.get_element("bufrHeaderCentre"),
             "data_category": message.get_element("dataCategory")

--- a/csv2bufr/cli.py
+++ b/csv2bufr/cli.py
@@ -135,7 +135,7 @@ def transform(ctx, csv_file, mapping, output_dir, station_metadata,
 
     click.echo("Writing data to file")
     for item in result:
-        key = item["md5"]
+        key = item['_meta']["md5"]
         bufr_filename = f"{output_dir}{os.sep}{key}.bufr4"
         with open(bufr_filename, "wb") as fh:
             fh.write(item["bufr4"])

--- a/tests/test_csv2bufr.py
+++ b/tests/test_csv2bufr.py
@@ -327,9 +327,9 @@ def test_transform(data_dict, station_dict, mapping_dict):
     result = transform(data, station_dict, mapping_dict)
     for item in result:
         assert isinstance(item, dict)
-        assert "md5" in item
+        assert "md5" in item["_meta"]
         assert "_meta" in item
-        assert item["md5"] == '981938dbd97be3e5adc8e7b1c6eb642c'
+        assert item["_meta"]["md5"] == "981938dbd97be3e5adc8e7b1c6eb642c"
 
 
 def test_json(data_dict, station_dict, mapping_dict, json_template,


### PR DESCRIPTION
This PR moves an output BUFR message object's `md5` key to `_meta`.  The md5 is already the key of the object item, and keeps downstream applications to processing "format" (i.e. `bufr4`, `geojson`) and metadata (i.e. `_meta`) keys.