### PR TITLE
add properties.identifier to GeoJSON responses

### DIFF
--- a/csv2bufr/__init__.py
+++ b/csv2bufr/__init__.py
@@ -399,7 +399,7 @@ class BUFRMessage:
         """
 
         result = self._extract(template)
-        result["id"] = identifier
+        result["properties"]["identifier"] = result["id"] = identifier
         result["properties"]["resultTime"] = datetime.now(timezone.utc).isoformat(timespec="seconds") # noqa
         return json.dumps(result, indent=4)
 

--- a/csv2bufr/resources/mappings/malawi_synop_json.geojson
+++ b/csv2bufr/resources/mappings/malawi_synop_json.geojson
@@ -9,6 +9,7 @@
         {"eccodes_key":"#1#heightOfStationGroundAboveMeanSeaLevel"}]
   },
   "properties": {
+    "identifier": null,
     "phenomenonTime": {"format":"{:04d}-{:02d}-{:02d}T{:02d}:{:02d}:00+00:00", "args": [
       {"eccodes_key":"#1#year"},
       {"eccodes_key":"#1#month"},

--- a/tests/test_csv2bufr.py
+++ b/tests/test_csv2bufr.py
@@ -100,6 +100,7 @@ def json_template():
                             {"eccodes_key": "#1#latitude"}]
         },
         "properties": {
+            "identifier": None,
             "phenomenonTime": {
                 "format": "{:04d}-{:02d}-{:02d}T{:02d}:{:02d}:00+00:00",
                 "args": [
@@ -157,6 +158,7 @@ def json_result():
             "coordinates": [0.0, 55.154]
         },
         "properties": {
+            "identifier": "981938dbd97be3e5adc8e7b1c6eb642c",
             "phenomenonTime": "2021-11-18T18:00:00+00:00",
             "resultTime": None,
             "observations": {


### PR DESCRIPTION
This PR adds a `properties.identifier` property to GeoJSON output, to support pygeoapi integration in wis2node.

cc @webb-ben