### PR TITLE
more efficient Dockerfile and more robust metadata processing of wigosId

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,21 +31,22 @@ ENV DEBIAN_FRONTEND="noninteractive" \
 
 WORKDIR /tmp/eccodes
 
-COPY . /tmp/csv2bufr
-
 RUN echo "Acquire::Check-Valid-Until \"false\";\nAcquire::Check-Date \"false\";" | cat > /etc/apt/apt.conf.d/10no--check-valid-until \
     && apt-get update -y \
     && apt-get install -y ${BUILD_PACKAGES} python3 python3-pip libffi-dev python3-dev \
     && curl https://confluence.ecmwf.int/download/attachments/45757960/eccodes-${ECCODES_VER}-Source.tar.gz --output eccodes-${ECCODES_VER}-Source.tar.gz \
     && tar xzf eccodes-${ECCODES_VER}-Source.tar.gz \
     && mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=${ECCODES_DIR} ../eccodes-${ECCODES_VER}-Source && make && ctest && make install \
-    && cd /tmp/csv2bufr \
-    && python3 setup.py install \
     && cd / && rm -rf /tmp/eccodes /tmp/csv2bufr \
     && apt-get remove --purge -y ${BUILD_PACKAGES} \
     && apt autoremove -y  \
     && apt-get -q clean \
     && rm -rf /var/lib/apt/lists/*
+
+COPY . /tmp/csv2bufr
+
+RUN cd /tmp/csv2bufr && python3 setup.py install
+    
 
 WORKDIR /
 

--- a/csv2bufr/__init__.py
+++ b/csv2bufr/__init__.py
@@ -459,10 +459,13 @@ class BUFRMessage:
         # extract wigos ID from metadata
         # Is this the right place for this?
         # ==================================================
-        wigosID = metadata["wigosIds"][0]["wid"]
-        tokens = parse_wigos_id(wigosID)
-        for token in tokens:
-            metadata["wigosIds"][0][token] = tokens[token]
+        try:
+            wigosID = metadata["wigosIds"][0]["wid"]
+            tokens = parse_wigos_id(wigosID)
+            for token in tokens:
+                metadata["wigosIds"][0][token] = tokens[token]
+        except (Exception, AssertionError):
+            LOGGER.warning("WigosID not parsed automatically. wigosID element not in metadata?")
         # ==================================================
         # now parse the data.
         # ==================================================

--- a/csv2bufr/__init__.py
+++ b/csv2bufr/__init__.py
@@ -654,6 +654,7 @@ def transform(data: str, metadata: dict, mappings: dict,
         result["_meta"] = {
             "identifier": rmk,
             "md5": rmk,
+            "wigos_id": metadata['wigosIds'][0]['wid'] if 'wigosIds' in metadata else "N/A" ,
             "data_date": message.get_datetime(),
             "originating_centre": message.get_element("bufrHeaderCentre"),
             "data_category": message.get_element("dataCategory")

--- a/csv2bufr/__init__.py
+++ b/csv2bufr/__init__.py
@@ -654,7 +654,6 @@ def transform(data: str, metadata: dict, mappings: dict,
         result["_meta"] = {
             "identifier": rmk,
             "md5": rmk,
-            "wigos_id": metadata['wigosIds'][0]['wid'],
             "data_date": message.get_datetime(),
             "originating_centre": message.get_element("bufrHeaderCentre"),
             "data_category": message.get_element("dataCategory")


### PR DESCRIPTION
More efficient Dockerfile that avoids rebuilding eccodes in case of changes to the csv2bufr code. 
Wrap wigos_id processing in error handling to be able to pass in metadata without this element. 
Hard coding the wigos_id appears to contradict the idea of the mapping, where elements are flexible