### PR TITLE
rename GeoJSON property for WSI

### DIFF
--- a/csv2bufr/resources/mappings/malawi_synop_json.geojson
+++ b/csv2bufr/resources/mappings/malawi_synop_json.geojson
@@ -18,7 +18,7 @@
       {"eccodes_key":"#1#minute"}
     ]},
     "resultTime": null,
-    "wmo:wigos_station_identifier": {
+    "wigos_station_identifier": {
         "format":"{}-{}-{}-{}",
         "args": [
             {"eccodes_key": "#1#wigosIdentifierSeries"},

--- a/csv2bufr/resources/mappings/wmo_om_rc0.geojson
+++ b/csv2bufr/resources/mappings/wmo_om_rc0.geojson
@@ -22,7 +22,7 @@
       {"eccodes_key":"#1#minute"}
     ]},
     "resultTime": null,
-    "wmo:wigos_station_identifier":{
+    "wigos_station_identifier":{
       "format":"{:.0f}-{:.0f}-{:.0f}-{}",
       "args":[
       {"eccodes_key":"#1#wigosIdentifierSeries"},


### PR DESCRIPTION
Renames `wmo:wigos_station_identifier` to `wigos_station_identifier`

The driver here is using the GeoJSON properties as named/`kwargs` parameters in downstream tools that use API machinery.  Example in [OWSLib](https://geopython.github.io/OWSLib):

```python
from owslib.ogcapi.features import Features

url = 'http://localhost:8999/pygeoapi'

api = Features(url)

namitambo_obs = api.collection_items(
    collection_id='data.core.observations-surface-land.mw.fwcl.landfixed',
    wigos_station_identifier='0-454-2-AWSNAMITAMBO')
```

cc @webb-ben