### PR TITLE
add geometry support to _meta

### DIFF
--- a/csv2bufr/__init__.py
+++ b/csv2bufr/__init__.py
@@ -596,6 +596,7 @@ def transform(data: str, metadata: dict, mappings: dict) -> Iterator[dict]:
     The ["_meta"] element includes the following:
 
         - ["identifier"] = identifier for report (WIGOS_<WSI>_<ISO8601>);
+        - ["geometry"] = GeoJSON geometry object;
         - ["md5"] = md5 checksum of BUFR encoded data;
         - ["wigos_id"] = WIGOS identifier;
         - ["data_date"] = characteristic date of data;

--- a/csv2bufr/__init__.py
+++ b/csv2bufr/__init__.py
@@ -701,6 +701,13 @@ def transform(data: str, metadata: dict, mappings: dict) -> Iterator[dict]:
         result["_meta"] = {
             "identifier": rmk,
             "md5": message.md5(),
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    message.get_element('#1#longitude'),
+                    message.get_element('#1#latitude')
+                ]
+            },
             "wigos_id": wsi,
             "data_date": message.get_datetime(),
             "originating_centre": message.get_element("bufrHeaderCentre"),

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -120,6 +120,7 @@ The command line interface uses the ``transform`` function from the csv2bufr mod
    for item in result:
        # get id and phenomenon time to use in output filename
        wsid = item["_meta"]["wigos_id"]  # WIGOS station ID
+       geometry = item["_meta"]["geometry"]  # GeoJSON geometry object
        timestamp = item["_meta"]["data_date"]  # phenomenonTime as datetime object
        timestamp = timestamp.strftime("%Y%m%dT%H%MZ")  # convert to string
        # set filename
@@ -135,7 +136,8 @@ Each item returned contains a dictionary with the following elements:
 - ``item["_meta"]`` dictionary containing metadata elements
 - ``item["_meta"]["md5"]`` the md5 checksum of the encoded BUFR data
 - ``item["_meta"]["identifier"]`` identifier for result (set combination of ``wigos_id`` and ``data_date``)
+- ``item["_meta"]["geometry"]`` GeoJSON geometry object of location of data
 - ``item["_meta"]["wigos_id"]`` WIGOS station identifier
 - ``item["_meta"]["data_date"]`` characteristic date of data contained in result (from BUFR)
-- ``item["_meta"]["originating_centre"]`` originating centre for data  (from BUFR)
+- ``item["_meta"]["originating_centre"]`` originating centre for data (from BUFR)
 - ``item["_meta"]["data_category"]`` data category (from BUFR)

--- a/tests/test_csv2bufr.py
+++ b/tests/test_csv2bufr.py
@@ -230,8 +230,9 @@ def test_transform(data_dict, station_dict, mapping_dict):
         assert isinstance(item, dict)
         assert "_meta" in item
 
-        item_meta_keys = ['data_category', 'data_date', 'identifier',
-                          'md5', 'originating_centre', 'wigos_id']
+        item_meta_keys = ['data_category', 'data_date', 'geometry',
+                          'identifier', 'md5', 'originating_centre',
+                          'wigos_id']
 
         assert sorted(item["_meta"].keys()) == item_meta_keys
 


### PR DESCRIPTION
This PR adds GeoJSON geometry to the a result's `_meta` object so that they can be used in downstream processing (without processing the data payload) as desired.  The context here is wis2box MQP message publishing (which is GeoJSON).