### PR TITLE
Addition of default group and pin of uid/gid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,11 @@ COPY . /tmp/csv2bufr
 
 RUN cd /tmp/csv2bufr && python3 setup.py install
 
-RUN adduser wis2user
+RUN groupadd -g 1001 wis2users
+RUN useradd -u 1001 wis2user
+RUN usermod -aG wis2users wis2user
+
+
 USER wis2user
 WORKDIR /home/wis2user
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,6 @@ ENV DEBIAN_FRONTEND="noninteractive" \
 RUN apt-get update -y \
     && apt-get install -y vim emacs nedit nano
 
-
 WORKDIR /tmp
 
 COPY . /tmp/csv2bufr
@@ -40,7 +39,6 @@ RUN cd /tmp/csv2bufr && python3 setup.py install
 RUN groupadd -g 1001 wis2users
 RUN useradd -u 1001 wis2user
 RUN usermod -aG wis2users wis2user
-
 
 USER wis2user
 WORKDIR /home/wis2user


### PR DESCRIPTION
When mounting external volumes there are permission issues unless uid and gid specified. This change allows the gid and uid to be specified as part of docker run ... with consistent results.